### PR TITLE
Add Unity for PSM Whitelist Hack.

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -244,7 +244,7 @@ int main(){
 						drawText(460,error,red);
 					}
 					sprintf(query,"%s","CREATE TRIGGER CHANGE_FEATURE_PSTV AFTER INSERT ON tbl_appinfo WHEN 1=1 BEGIN UPDATE tbl_appinfo SET val = val & ~8 WHERE key='2412347057' and titleid=new.titleid; END;");
-					drawText(120,"Executing 5th query",white);
+					drawText(140,"Executing 5th query",white);
 					fd = sqlite3_exec(db, query, callback, 0, &zErrMsg);
 					if( fd != SQLITE_OK ){
 						char error[512];
@@ -253,11 +253,11 @@ int main(){
 						drawText(460,error,red);
 					}		
 					// Closing app.db
-					drawText(140,"Closing app database",white);
+					drawText(160,"Closing app database",white);
 					sqlite3_close(db);
 					
 					//Triggering a database restore
-					drawText(160,"Nulling MID value in id.dat",white);
+					drawText(180,"Nulling MID value in id.dat",white);
 					FILE* fd = fopen("ux0:/id.dat", "r+");
 					fseek(fd, 0, SEEK_END);
 					int id_size = ftell(fd);
@@ -346,7 +346,7 @@ int main(){
 						drawText(460,error,red);
 					}
 					sprintf(query,"%s","DROP TRIGGER CHANGE_FEATURE_PSTV;");
-					drawText(120,"Executing 5th query",white);
+					drawText(140,"Executing 5th query",white);
 					fd = sqlite3_exec(db, query, callback, 0, &zErrMsg);
 					if( fd != SQLITE_OK ){
 						char error[512];
@@ -356,11 +356,11 @@ int main(){
 					}
 		
 					// Closing app.db
-					drawText(140,"Closing app database",white);
+					drawText(160,"Closing app database",white);
 					sqlite3_close(db);
 					
 					//Triggering a database restore
-					drawText(160,"Nulling MID value in id.dat",white);
+					drawText(180,"Nulling MID value in id.dat",white);
 					FILE* fd = fopen("ux0:/id.dat", "r+");
 					fseek(fd, 0, SEEK_END);
 					int id_size = ftell(fd);

--- a/source/main.c
+++ b/source/main.c
@@ -243,7 +243,15 @@ int main(){
 						sqlite3_free(zErrMsg);
 						drawText(460,error,red);
 					}
-		
+					sprintf(query,"%s","CREATE TRIGGER CHANGE_FEATURE_PSTV AFTER INSERT ON tbl_appinfo WHEN 1=1 BEGIN UPDATE tbl_appinfo SET val = val & ~8 WHERE key='2412347057' and titleid=new.titleid; END;");
+					drawText(120,"Executing 5th query",white);
+					fd = sqlite3_exec(db, query, callback, 0, &zErrMsg);
+					if( fd != SQLITE_OK ){
+						char error[512];
+						sprintf(error, "ERROR: SQL error: %s", zErrMsg);
+						sqlite3_free(zErrMsg);
+						drawText(460,error,red);
+					}		
 					// Closing app.db
 					drawText(140,"Closing app database",white);
 					sqlite3_close(db);
@@ -330,6 +338,15 @@ int main(){
 					}
 					sprintf(query,"%s","DROP TRIGGER CHANGE_CATEGORY_GD;");
 					drawText(120,"Executing 4th query",white);
+					fd = sqlite3_exec(db, query, callback, 0, &zErrMsg);
+					if( fd != SQLITE_OK ){
+						char error[512];
+						sprintf(error, "ERROR: SQL error: %s", zErrMsg);
+						sqlite3_free(zErrMsg);
+						drawText(460,error,red);
+					}
+					sprintf(query,"%s","DROP TRIGGER CHANGE_FEATURE_PSTV;");
+					drawText(120,"Executing 5th query",white);
 					fd = sqlite3_exec(db, query, callback, 0, &zErrMsg);
 					if( fd != SQLITE_OK ){
 						char error[512];


### PR DESCRIPTION
Running

CREATE TRIGGER CHANGE_FEATURE_PSTV AFTER INSERT ON tbl_appinfo
WHEN 1=1
BEGIN UPDATE tbl_appinfo SET val = val & ~8 WHERE key='2412347057' and titleid=new.titleid;
END;

Enables all PSM for UNITY games to run on PSTV.