### PR TITLE
Fix Memory Card Linking Issue

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -244,7 +244,7 @@ int main(){
 						drawText(460,error,red);
 					}
 					sprintf(query,"%s","CREATE TRIGGER CHANGE_FEATURE_PSTV AFTER INSERT ON tbl_appinfo WHEN 1=1 BEGIN UPDATE tbl_appinfo SET val = val & ~8 WHERE key='2412347057' and titleid=new.titleid; END;");
-					drawText(120,"Executing 5th query",white);
+					drawText(140,"Executing 5th query",white);
 					fd = sqlite3_exec(db, query, callback, 0, &zErrMsg);
 					if( fd != SQLITE_OK ){
 						char error[512];
@@ -253,11 +253,11 @@ int main(){
 						drawText(460,error,red);
 					}		
 					// Closing app.db
-					drawText(140,"Closing app database",white);
+					drawText(160,"Closing app database",white);
 					sqlite3_close(db);
 					
 					//Triggering a database restore
-					drawText(160,"Nulling MID value in id.dat",white);
+					drawText(180,"Nulling MID value in id.dat",white);
 					FILE* fd = fopen("ux0:/id.dat", "r+");
 					fseek(fd, 0, SEEK_END);
 					int id_size = ftell(fd);
@@ -346,7 +346,7 @@ int main(){
 						drawText(460,error,red);
 					}
 					sprintf(query,"%s","DROP TRIGGER CHANGE_FEATURE_PSTV;");
-					drawText(120,"Executing 5th query",white);
+					drawText(140,"Executing 5th query",white);
 					fd = sqlite3_exec(db, query, callback, 0, &zErrMsg);
 					if( fd != SQLITE_OK ){
 						char error[512];
@@ -356,11 +356,11 @@ int main(){
 					}
 		
 					// Closing app.db
-					drawText(140,"Closing app database",white);
+					drawText(160,"Closing app database",white);
 					sqlite3_close(db);
 					
 					//Triggering a database restore
-					drawText(160,"Nulling MID value in id.dat",white);
+					drawText(180,"Nulling MID value in id.dat",white);
 					FILE* fd = fopen("ux0:/id.dat", "r+");
 					fseek(fd, 0, SEEK_END);
 					int id_size = ftell(fd);

--- a/source/main.c
+++ b/source/main.c
@@ -257,29 +257,8 @@ int main(){
 					sqlite3_close(db);
 					
 					//Triggering a database restore
-					drawText(180,"Nulling MID value in id.dat",white);
-					FILE* fd = fopen("ux0:/id.dat", "r+");
-					fseek(fd, 0, SEEK_END);
-					int id_size = ftell(fd);
-					char* id_buf = (char*)malloc(id_size);
-					fseek(fd, 0, SEEK_SET);
-					fread(id_buf, id_size, 1, fd);
-					char* mid_offs = strstr(id_buf, "MID=");
-					if (mid_offs == NULL){
-						fseek(fd, 0, SEEK_END); // Just to be sure
-						fwrite("\nMID=\n", 6, 1, fd);
-						fclose(fd);
-					}else{
-						fclose(fd);
-						fd = fopen("ux0:/id.dat", "w+");
-						char* mid_end = strstr(mid_offs, "\n");
-						if (mid_end == NULL) fwrite(id_buf, mid_offs - id_buf + 4, 1, fd);
-						else{
-							memcpy(&mid_offs[4], mid_end, id_size - (mid_end - id_buf));
-							fwrite(id_buf, id_size - (mid_end - (mid_offs + 4)), 1, fd);
-						}
-						fclose(fd);
-					}
+					sceRegMgrSetKeyInt("/CONFIG/SHELL", "appdb_rebuild_flag", 0);
+					
 					
 					drawText(200,"Done!",green);
 					drawText(240,"To make changes effective, a reboot is required",green);
@@ -360,29 +339,7 @@ int main(){
 					sqlite3_close(db);
 					
 					//Triggering a database restore
-					drawText(180,"Nulling MID value in id.dat",white);
-					FILE* fd = fopen("ux0:/id.dat", "r+");
-					fseek(fd, 0, SEEK_END);
-					int id_size = ftell(fd);
-					char* id_buf = (char*)malloc(id_size);
-					fseek(fd, 0, SEEK_SET);
-					fread(id_buf, id_size, 1, fd);
-					char* mid_offs = strstr(id_buf, "MID=");
-					if (mid_offs == NULL){
-						fseek(fd, 0, SEEK_END); // Just to be sure
-						fwrite("\nMID=\n", 6, 1, fd);
-						fclose(fd);
-					}else{
-						fclose(fd);
-						fd = fopen("ux0:/id.dat", "w+");
-						char* mid_end = strstr(mid_offs, "\n");
-						if (mid_end == NULL) fwrite(id_buf, mid_offs - id_buf + 4, 1, fd);
-						else{
-							memcpy(&mid_offs[4], mid_end, id_size - (mid_end - id_buf));
-							fwrite(id_buf, id_size - (mid_end - (mid_offs + 4)), 1, fd);
-						}
-						fclose(fd);
-					}
+					sceRegMgrSetKeyInt("/CONFIG/SHELL", "appdb_rebuild_flag", 0);
 					
 					drawText(200,"Done!",green);
 					drawText(220,"To make changes effective, a reboot is required",green);

--- a/source/main.c
+++ b/source/main.c
@@ -243,7 +243,15 @@ int main(){
 						sqlite3_free(zErrMsg);
 						drawText(460,error,red);
 					}
-		
+					sprintf(query,"%s","CREATE TRIGGER CHANGE_FEATURE_PSTV AFTER INSERT ON tbl_appinfo WHEN 1=1 BEGIN UPDATE tbl_appinfo SET val = val & ~8 WHERE key='2412347057' and titleid=new.titleid; END;");
+					drawText(120,"Executing 5th query",white);
+					fd = sqlite3_exec(db, query, callback, 0, &zErrMsg);
+					if( fd != SQLITE_OK ){
+						char error[512];
+						sprintf(error, "ERROR: SQL error: %s", zErrMsg);
+						sqlite3_free(zErrMsg);
+						drawText(460,error,red);
+					}		
 					// Closing app.db
 					drawText(140,"Closing app database",white);
 					sqlite3_close(db);
@@ -330,6 +338,15 @@ int main(){
 					}
 					sprintf(query,"%s","DROP TRIGGER CHANGE_CATEGORY_GD;");
 					drawText(120,"Executing 4th query",white);
+					fd = sqlite3_exec(db, query, callback, 0, &zErrMsg);
+					if( fd != SQLITE_OK ){
+						char error[512];
+						sprintf(error, "ERROR: SQL error: %s", zErrMsg);
+						sqlite3_free(zErrMsg);
+						drawText(460,error,red);
+					}
+					sprintf(query,"%s","DROP TRIGGER CHANGE_FEATURE_PSTV;");
+					drawText(120,"Executing 5th query",white);
 					fd = sqlite3_exec(db, query, callback, 0, &zErrMsg);
 					if( fd != SQLITE_OK ){
 						char error[512];


### PR DESCRIPTION
I heard some users complaining that there memcard was locked after installing/uninstalling-
i can only assume this is caused by editing id.dat

So in order to fix this i have changed the way it triggers app.db update to simply setting
the registry key ``/CONFIG/SHELL/appdb_rebuild_flag`` to 0.